### PR TITLE
Update notificator.cpp

### DIFF
--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -113,7 +113,7 @@ FreedesktopImage::FreedesktopImage(const QImage &img):
 {
     // Convert 00xAARRGGBB to RGBA bytewise (endian-independent) format
     QImage tmp = img.convertToFormat(QImage::Format_ARGB32);
-    const uint32_t *data = reinterpret_cast<const uint32_t*>(tmp.constBits());
+    const uint32_t *data = reinterpret_cast<const uint32_t*>(tmp.bits());
 
     unsigned int num_pixels = width * height;
     image.resize(num_pixels * BYTES_PER_PIXEL);


### PR DESCRIPTION
Fix old error of compilation file "notificator.cpp":
"src/qt/notificator.cpp: In constructor ‘FreedesktopImage::FreedesktopImage(const QImage&)’:
src/qt/notificator.cpp:116: error: ‘class QImage’ has no member named ‘constBits’"
